### PR TITLE
RHCLOUD-41667: defines custom types and defintions for valid api versions and operations

### DIFF
--- a/kessel/common/common.go
+++ b/kessel/common/common.go
@@ -1,0 +1,29 @@
+package common
+
+// ApiVersion defines an API version
+type ApiVersion string
+
+var V1 ApiVersion = "v1"
+var V1Beta2 ApiVersion = "v1beta2"
+
+// ValidApiVersions defines all the current API versions supported
+var ValidApiVersions = map[ApiVersion]bool{
+	V1:      true,
+	V1Beta2: true,
+}
+
+// ApiOperation defines an operation the API can perform via an API endpoint
+type ApiOperation string
+
+var GetReadyZ ApiOperation = "GetReadyZ"
+var GetLiveZ ApiOperation = "GetLiveZ"
+var Check ApiOperation = "Check"
+var CheckForUpdate ApiOperation = "CheckForUpdate"
+var ReportResource ApiOperation = "ReportResource"
+var DeleteResource ApiOperation = "DeleteResource"
+
+// ValidApiOperations maps an API version to all supported operations of that API for validation purposes
+var ValidApiOperations = map[ApiVersion]map[ApiOperation]bool{
+	V1:      {GetReadyZ: true, GetLiveZ: true},
+	V1Beta2: {Check: true, CheckForUpdate: true, ReportResource: true, DeleteResource: true},
+}


### PR DESCRIPTION
The purpose of these changes is to simplify checks and validations for services that consume to SDK and need to peform their own validation checks specific to API versions and/or operations

Initial usecase is for Kessel Inventory Consumer as a means to cleanly and easily validate required headers are set using types vs strings as well as validate operation types for an API version, without all this code being isolated to the consumer alone.

Long term, if this becomes a management mess, we can leverage something like [go generate](https://go.dev/blog/generate) to automatically generate this file based on some source in Inventory API