### PR TITLE
RHCLOUD-46705 - Implement principal from RH identity helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build: .env ## Build example binaries
 	@go build -o bin/fetch_workspace ./examples/rbac/fetch_workspace.go
 	@go build -o bin/list_workspaces ./examples/rbac/list_workspaces.go
 	@go build -o bin/check_bulk_example ./examples/grpc/check_bulk.go
+	@go build -o bin/console-principal-example ./examples/console/console_principal.go
 
 .PHONY: lint
 lint: ## Run golangci-lint
@@ -36,7 +37,7 @@ lint: ## Run golangci-lint
 		echo "Linting SDK code..."; \
 		golangci-lint run -v ./kessel/...; \
 		echo "Linting example files individually..."; \
-		for file in examples/grpc/*.go examples/rbac/*.go; do \
+		for file in examples/grpc/*.go examples/rbac/*.go examples/console/*.go; do \
 			echo "Linting $$file"; \
 			golangci-lint run -v $$file; \
 		done'

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: ## Run golangci-lint
 		echo "Linting SDK code..."; \
 		golangci-lint run -v ./kessel/...; \
 		echo "Linting example files individually..."; \
-		for file in examples/grpc/*.go examples/rbac/*.go examples/console/*.go; do \
+		for file in examples/*/*.go; do \
 			echo "Linting $$file"; \
 			golangci-lint run -v $$file; \
 		done'

--- a/examples/console/console_principal.go
+++ b/examples/console/console_principal.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"log"
+
+	"github.com/project-kessel/kessel-sdk-go/kessel/console"
+)
+
+func consolePrincipal() {
+	// --- From a parsed User identity ---
+	userIdentity := map[string]any{
+		"type":   "User",
+		"org_id": "12345",
+		"user":   map[string]any{"user_id": "7393748", "username": "jdoe"},
+	}
+
+	subject, err := console.PrincipalFromRHIdentity(userIdentity)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("User principal:            %s", subject.Resource.ResourceId)
+
+	// --- From a parsed ServiceAccount identity ---
+	saIdentity := map[string]any{
+		"type":   "ServiceAccount",
+		"org_id": "456",
+		"service_account": map[string]any{
+			"user_id":  "12345",
+			"username": "service-account-b69eaf9e",
+		},
+	}
+
+	subject, err = console.PrincipalFromRHIdentity(saIdentity)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("ServiceAccount principal:  %s", subject.Resource.ResourceId)
+
+	// --- From a raw base64-encoded x-rh-identity header ---
+	headerPayload := map[string]any{
+		"identity": map[string]any{
+			"type":   "User",
+			"org_id": "12345",
+			"user":   map[string]any{"user_id": "7393748", "username": "jdoe"},
+		},
+	}
+
+	data, err := json.Marshal(headerPayload)
+	if err != nil {
+		panic(err)
+	}
+	header := base64.StdEncoding.EncodeToString(data)
+
+	subject, err = console.PrincipalFromRHIdentityHeader(header)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("From header principal:     %s", subject.Resource.ResourceId)
+}
+
+func main() { consolePrincipal() }

--- a/kessel/console/console.go
+++ b/kessel/console/console.go
@@ -1,0 +1,78 @@
+package console
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+	v2 "github.com/project-kessel/kessel-sdk-go/kessel/rbac/v2"
+)
+
+const defaultDomain = "redhat"
+
+var identityTypeFields = map[string]string{
+	"User":           "user",
+	"ServiceAccount": "service_account",
+}
+
+func extractUserID(identity map[string]any) (string, error) {
+	if identity == nil {
+		return "", fmt.Errorf("identity must not be nil")
+	}
+
+	identityType, _ := identity["type"].(string)
+	field, ok := identityTypeFields[identityType]
+	if !ok {
+		supported := make([]string, 0, len(identityTypeFields))
+		for k := range identityTypeFields {
+			supported = append(supported, k)
+		}
+		return "", fmt.Errorf("unsupported identity type: %q (supported: %v)", identityType, supported)
+	}
+
+	details, ok := identity[field].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("identity type %q is missing the %q field", identityType, field)
+	}
+
+	userID, _ := details["user_id"].(string)
+	if userID == "" {
+		return "", fmt.Errorf("unable to resolve user ID from %s identity (tried: user_id)", identityType)
+	}
+
+	return userID, nil
+}
+
+func PrincipalFromRHIdentity(identity map[string]any, domain ...string) (*v1beta2.SubjectReference, error) {
+	d := defaultDomain
+	if len(domain) > 0 && domain[0] != "" {
+		d = domain[0]
+	}
+
+	userID, err := extractUserID(identity)
+	if err != nil {
+		return nil, err
+	}
+
+	return v2.PrincipalSubject(userID, d), nil
+}
+
+func PrincipalFromRHIdentityHeader(header string, domain ...string) (*v1beta2.SubjectReference, error) {
+	decoded, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode identity header: %w", err)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(decoded, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode identity header: %w", err)
+	}
+
+	identity, ok := envelope["identity"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("identity header is missing the \"identity\" envelope key")
+	}
+
+	return PrincipalFromRHIdentity(identity, domain...)
+}

--- a/kessel/console/console.go
+++ b/kessel/console/console.go
@@ -46,7 +46,7 @@ func extractUserID(identity map[string]any) (string, error) {
 
 func PrincipalFromRHIdentity(identity map[string]any, domain ...string) (*v1beta2.SubjectReference, error) {
 	d := defaultDomain
-	if len(domain) > 0 && domain[0] != "" {
+	if len(domain) > 0 {
 		d = domain[0]
 	}
 

--- a/kessel/console/console_test.go
+++ b/kessel/console/console_test.go
@@ -1,0 +1,244 @@
+package console
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrincipalFromRHIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		identity       map[string]any
+		domain         string
+		expectedResID  string
+		expectedErrMsg string
+	}{
+		{
+			name: "user identity",
+			identity: map[string]any{
+				"type":   "User",
+				"org_id": "12345",
+				"user":   map[string]any{"user_id": "7393748", "username": "jdoe"},
+			},
+			expectedResID: "redhat/7393748",
+		},
+		{
+			name: "service account identity",
+			identity: map[string]any{
+				"type":   "ServiceAccount",
+				"org_id": "456",
+				"service_account": map[string]any{
+					"user_id":  "sa-001",
+					"username": "service-account-sa-001",
+				},
+			},
+			expectedResID: "redhat/sa-001",
+		},
+		{
+			name: "custom domain",
+			identity: map[string]any{
+				"type": "User",
+				"user": map[string]any{"user_id": "42"},
+			},
+			domain:        "customdomain",
+			expectedResID: "customdomain/42",
+		},
+		{
+			name: "unsupported type",
+			identity: map[string]any{
+				"type": "System",
+			},
+			expectedErrMsg: `unsupported identity type: "System"`,
+		},
+		{
+			name:           "nil identity",
+			expectedErrMsg: "identity must not be nil",
+		},
+		{
+			name: "user type missing user field",
+			identity: map[string]any{
+				"type": "User",
+			},
+			expectedErrMsg: `identity type "User" is missing the "user" field`,
+		},
+		{
+			name: "service account type missing service_account field",
+			identity: map[string]any{
+				"type": "ServiceAccount",
+			},
+			expectedErrMsg: `identity type "ServiceAccount" is missing the "service_account" field`,
+		},
+		{
+			name: "user type empty user_id",
+			identity: map[string]any{
+				"type": "User",
+				"user": map[string]any{"username": "jdoe"},
+			},
+			expectedErrMsg: "unable to resolve user ID from User identity",
+		},
+		{
+			name: "service account type empty user_id",
+			identity: map[string]any{
+				"type":            "ServiceAccount",
+				"service_account": map[string]any{"username": "sa"},
+			},
+			expectedErrMsg: "unable to resolve user ID from ServiceAccount identity",
+		},
+		{
+			name: "user field not a map",
+			identity: map[string]any{
+				"type": "User",
+				"user": "not-a-map",
+			},
+			expectedErrMsg: `identity type "User" is missing the "user" field`,
+		},
+		{
+			name: "missing type field",
+			identity: map[string]any{
+				"org_id": "123",
+			},
+			expectedErrMsg: "unsupported identity type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+
+			if tt.domain != "" {
+				_, err = PrincipalFromRHIdentity(tt.identity, tt.domain)
+			} else {
+				_, err = PrincipalFromRHIdentity(tt.identity)
+			}
+
+			if tt.expectedErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPrincipalFromRHIdentity_SubjectFields(t *testing.T) {
+	identity := map[string]any{
+		"type": "User",
+		"user": map[string]any{"user_id": "7393748"},
+	}
+
+	subj, err := PrincipalFromRHIdentity(identity)
+	require.NoError(t, err)
+
+	assert.Equal(t, "principal", subj.Resource.ResourceType)
+	assert.Equal(t, "redhat/7393748", subj.Resource.ResourceId)
+	assert.Equal(t, "rbac", subj.Resource.Reporter.Type)
+	assert.Nil(t, subj.Relation)
+}
+
+func TestPrincipalFromRHIdentity_CustomDomainFields(t *testing.T) {
+	identity := map[string]any{
+		"type": "User",
+		"user": map[string]any{"user_id": "42"},
+	}
+
+	subj, err := PrincipalFromRHIdentity(identity, "customdomain")
+	require.NoError(t, err)
+
+	assert.Equal(t, "customdomain/42", subj.Resource.ResourceId)
+}
+
+func TestPrincipalFromRHIdentityHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		header         string
+		domain         string
+		expectedResID  string
+		expectedErrMsg string
+	}{
+		{
+			name:          "valid user header",
+			header:        encodeHeader(t, map[string]any{"identity": map[string]any{"type": "User", "user": map[string]any{"user_id": "123"}}}),
+			expectedResID: "redhat/123",
+		},
+		{
+			name:          "valid header with custom domain",
+			header:        encodeHeader(t, map[string]any{"identity": map[string]any{"type": "User", "user": map[string]any{"user_id": "456"}}}),
+			domain:        "example",
+			expectedResID: "example/456",
+		},
+		{
+			name:           "malformed base64",
+			header:         "not-valid-base64!@#$",
+			expectedErrMsg: "failed to decode identity header",
+		},
+		{
+			name:           "invalid JSON",
+			header:         base64.StdEncoding.EncodeToString([]byte("not json")),
+			expectedErrMsg: "failed to decode identity header",
+		},
+		{
+			name:           "missing identity envelope key",
+			header:         encodeHeader(t, map[string]any{"other": "data"}),
+			expectedErrMsg: `identity header is missing the "identity" envelope key`,
+		},
+		{
+			name:           "unsupported type in header",
+			header:         encodeHeader(t, map[string]any{"identity": map[string]any{"type": "X509"}}),
+			expectedErrMsg: `unsupported identity type: "X509"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+
+			if tt.domain != "" {
+				_, err = PrincipalFromRHIdentityHeader(tt.header, tt.domain)
+			} else {
+				_, err = PrincipalFromRHIdentityHeader(tt.header)
+			}
+
+			if tt.expectedErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPrincipalFromRHIdentityHeader_SubjectFields(t *testing.T) {
+	header := encodeHeader(t, map[string]any{
+		"identity": map[string]any{
+			"type":   "ServiceAccount",
+			"org_id": "org-1",
+			"service_account": map[string]any{
+				"user_id":  "sa-999",
+				"username": "service-account-sa-999",
+			},
+		},
+	})
+
+	subj, err := PrincipalFromRHIdentityHeader(header)
+	require.NoError(t, err)
+
+	assert.Equal(t, "principal", subj.Resource.ResourceType)
+	assert.Equal(t, "redhat/sa-999", subj.Resource.ResourceId)
+	assert.Equal(t, "rbac", subj.Resource.Reporter.Type)
+	assert.Nil(t, subj.Relation)
+}
+
+func encodeHeader(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(data)
+}

--- a/kessel/console/console_test.go
+++ b/kessel/console/console_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,12 +108,13 @@ func TestPrincipalFromRHIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var subj *v1beta2.SubjectReference
 			var err error
 
 			if tt.domain != "" {
-				_, err = PrincipalFromRHIdentity(tt.identity, tt.domain)
+				subj, err = PrincipalFromRHIdentity(tt.identity, tt.domain)
 			} else {
-				_, err = PrincipalFromRHIdentity(tt.identity)
+				subj, err = PrincipalFromRHIdentity(tt.identity)
 			}
 
 			if tt.expectedErrMsg != "" {
@@ -122,6 +124,7 @@ func TestPrincipalFromRHIdentity(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResID, subj.Resource.ResourceId)
 		})
 	}
 }
@@ -196,12 +199,13 @@ func TestPrincipalFromRHIdentityHeader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var subj *v1beta2.SubjectReference
 			var err error
 
 			if tt.domain != "" {
-				_, err = PrincipalFromRHIdentityHeader(tt.header, tt.domain)
+				subj, err = PrincipalFromRHIdentityHeader(tt.header, tt.domain)
 			} else {
-				_, err = PrincipalFromRHIdentityHeader(tt.header)
+				subj, err = PrincipalFromRHIdentityHeader(tt.header)
 			}
 
 			if tt.expectedErrMsg != "" {
@@ -211,6 +215,7 @@ func TestPrincipalFromRHIdentityHeader(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResID, subj.Resource.ResourceId)
 		})
 	}
 }


### PR DESCRIPTION
Adds `PrincipalFromRHIdentity()` and `PrincipalFromRHIdentityHeader` to new `console` pkg, enabling consumers to build principal SubjectReferences directly from platform identity dicts or raw x-rh-identity headers.

https://redhat.atlassian.net/browse/RHCLOUD-46705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Construct console principals from Red Hat identity data supplied as maps or base64-encoded headers; added an example demonstrating usage.

* **Tests**
  * Added comprehensive tests covering successful parsing and principal construction, plus extensive error-path checks for malformed or missing identity data.

* **Chores**
  * Build and lint workflows updated to include console examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->