### PR TITLE
RHCLOUD-47739 - Update locking mechanism for concurrent token refreshes

### DIFF
--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -17,11 +17,14 @@ All OAuth2 authentication uses the `kessel/auth` package backed by `github.com/z
 
 ### Token Caching and Refresh
 
-- `OAuth2ClientCredentials.GetToken` caches tokens in memory with a `sync.Mutex` for thread safety.
+- `OAuth2ClientCredentials.GetToken` caches tokens in memory with a `sync.RWMutex` and a generation counter for thread-safe, coalesced refresh.
+- **Fast path (read lock):** When the cached token is valid, concurrent callers acquire a shared read lock, snapshot the generation counter, and return immediately. Multiple goroutines read concurrently without contention.
+- **Slow path (write lock with double-checked locking):** When the token needs refreshing, callers acquire an exclusive write lock. After acquiring the lock, callers re-check whether the generation counter changed (indicating another goroutine already refreshed). If so, they return the freshly cached token without hitting SSO. This ensures N concurrent callers coalesce into exactly 1 SSO request per refresh cycle.
+- **ForceRefresh coalescing:** Concurrent `ForceRefresh: true` callers also coalesce. The post-lock recheck intentionally ignores `ForceRefresh` so that if another goroutine already refreshed, subsequent callers accept that token rather than issuing redundant SSO requests.
 - Tokens are considered invalid 5 minutes (`expirationWindow = 300` seconds) before their actual expiry. Do not change this buffer without understanding the downstream impact on concurrent callers.
 - If the token response omits `expires_in`, the SDK defaults to 3600 seconds (`defaultExpiresIn`). Do not assume the IdP always returns this field.
 - Use `GetTokenOptions.ForceRefresh = true` only when the caller has evidence the token was rejected (e.g., a 401 response). Do not force-refresh on every call.
-- Tests for concurrent token access exist (`TestConcurrentTokenAccess`). Any change to the caching or mutex logic must pass that test.
+- Tests for concurrent token access exist (`TestConcurrentTokenAccess`, `TestConcurrentTokenAccess_stale_token`, `TestConcurrentForceRefresh`). These use 20-goroutine barrier synchronization and strictly assert exactly 1 SSO call. Any change to the caching or mutex logic must pass all concurrent tests with `-race`.
 
 ## Transport Security (TLS and gRPC)
 

--- a/kessel/auth/auth.go
+++ b/kessel/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/client"
@@ -26,7 +27,8 @@ type OAuth2ClientCredentials struct {
 	clientSecret  string
 	tokenEndpoint string
 	cachedToken   RefreshTokenResponse
-	tokenMutex    sync.Mutex
+	tokenMutex    sync.RWMutex
+	generation    uint64
 }
 
 type FetchOIDCDiscoveryOptions struct {
@@ -58,7 +60,8 @@ func NewOAuth2ClientCredentials(clientId string, clientSecret string, tokenEndpo
 		clientSecret:  clientSecret,
 		tokenEndpoint: tokenEndpoint,
 		cachedToken:   RefreshTokenResponse{},
-		tokenMutex:    sync.Mutex{},
+		tokenMutex:    sync.RWMutex{},
+		generation:    0,
 	}
 }
 
@@ -82,21 +85,33 @@ func (o *OAuth2ClientCredentials) GetToken(ctx context.Context, options GetToken
 		httpClient = http.DefaultClient
 	}
 
+	// Snapshot generation before any lock so all concurrent callers that
+	// decide to refresh see the same value, regardless of lock ordering.
+	generation := atomic.LoadUint64(&o.generation)
+
+	o.tokenMutex.RLock()
 	if !options.ForceRefresh && o.isTokenValid() {
-		return o.cachedToken, nil
+		token := o.cachedToken
+		o.tokenMutex.RUnlock()
+		return token, nil
 	}
+	o.tokenMutex.RUnlock()
 
 	o.tokenMutex.Lock()
 	defer o.tokenMutex.Unlock()
 
-	if options.ForceRefresh {
-		o.cachedToken = RefreshTokenResponse{}
+	if atomic.LoadUint64(&o.generation) != generation && o.isTokenValid() {
+		return o.cachedToken, nil
 	}
 
 	var err error
 	o.cachedToken, err = o.refreshToken(ctx, httpClient)
+	if err != nil {
+		return RefreshTokenResponse{}, err
+	}
+	atomic.AddUint64(&o.generation, 1)
 
-	return o.cachedToken, err
+	return o.cachedToken, nil
 }
 
 func (o *OAuth2ClientCredentials) refreshToken(ctx context.Context, httpClient *http.Client) (RefreshTokenResponse, error) {

--- a/kessel/auth/auth_test.go
+++ b/kessel/auth/auth_test.go
@@ -395,7 +395,6 @@ func TestConcurrentTokenAccess(t *testing.T) {
 		mu.Lock()
 		callCount++
 		mu.Unlock()
-		// Add a small delay to simulate network latency
 		time.Sleep(50 * time.Millisecond)
 		response := map[string]interface{}{
 			"access_token": "shared-token-123",
@@ -411,16 +410,19 @@ func TestConcurrentTokenAccess(t *testing.T) {
 
 	credentials := NewOAuth2ClientCredentials("test-client", "test-secret", server.URL)
 
-	// Test concurrent access to GetToken
-	const numGoroutines = 5
+	const numGoroutines = 20
 	results := make(chan RefreshTokenResponse, numGoroutines)
 	errors := make(chan error, numGoroutines)
 
+	var ready sync.WaitGroup
+	ready.Add(numGoroutines)
+	gate := make(chan struct{})
+
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			token, err := credentials.GetToken(context.TODO(), GetTokenOptions{
-				ForceRefresh: false,
-			})
+			ready.Done()
+			<-gate
+			token, err := credentials.GetToken(context.TODO(), GetTokenOptions{})
 			if err != nil {
 				errors <- err
 			} else {
@@ -429,7 +431,9 @@ func TestConcurrentTokenAccess(t *testing.T) {
 		}()
 	}
 
-	// Collect results
+	ready.Wait()
+	close(gate)
+
 	var tokens []RefreshTokenResponse
 	for i := 0; i < numGoroutines; i++ {
 		select {
@@ -437,33 +441,188 @@ func TestConcurrentTokenAccess(t *testing.T) {
 			tokens = append(tokens, token)
 		case err := <-errors:
 			t.Errorf("Unexpected error in concurrent access: %v", err)
-		case <-time.After(5 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("Timeout waiting for concurrent operations to complete")
 		}
 	}
 
-	// All tokens should be the same (cached after first request)
 	if len(tokens) != numGoroutines {
 		t.Errorf("Expected %d tokens, got %d", numGoroutines, len(tokens))
 	}
 
-	expectedToken := "shared-token-123"
 	for i, token := range tokens {
-		if token.AccessToken != expectedToken {
-			t.Errorf("Token %d differs from expected: expected '%s', got '%s'", i, expectedToken, token.AccessToken)
+		if token.AccessToken != "shared-token-123" {
+			t.Errorf("Token %d: expected 'shared-token-123', got '%s'", i, token.AccessToken)
 		}
 	}
 
-	// The server should have been called only once due to caching and mutex protection
 	mu.Lock()
 	finalCallCount := callCount
 	mu.Unlock()
 
 	if finalCallCount != 1 {
-		t.Logf("Note: Server was called %d times (expected 1, but race conditions may cause multiple calls)", finalCallCount)
-		// Be more lenient here since the exact behavior depends on timing
-		if finalCallCount > numGoroutines {
-			t.Errorf("Expected server to be called at most %d times, but was called %d times", numGoroutines, finalCallCount)
+		t.Errorf("Thundering herd: SSO was called %d times, expected exactly 1", finalCallCount)
+	}
+}
+
+func TestConcurrentTokenAccess_stale_token(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		time.Sleep(50 * time.Millisecond)
+		response := map[string]interface{}{
+			"access_token": "refreshed-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
 		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("Failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	credentials := NewOAuth2ClientCredentials("test-client", "test-secret", server.URL)
+	credentials.cachedToken = RefreshTokenResponse{
+		AccessToken: "stale-token",
+		ExpiresAt:   time.Now().Add(60 * time.Second), // inside the 300s early-refresh window
+	}
+
+	const numGoroutines = 20
+	results := make(chan RefreshTokenResponse, numGoroutines)
+	errors := make(chan error, numGoroutines)
+
+	var ready sync.WaitGroup
+	ready.Add(numGoroutines)
+	gate := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			ready.Done()
+			<-gate
+			token, err := credentials.GetToken(context.TODO(), GetTokenOptions{})
+			if err != nil {
+				errors <- err
+			} else {
+				results <- token
+			}
+		}()
+	}
+
+	ready.Wait()
+	close(gate)
+
+	var tokens []RefreshTokenResponse
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case token := <-results:
+			tokens = append(tokens, token)
+		case err := <-errors:
+			t.Errorf("Unexpected error in concurrent access: %v", err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timeout waiting for concurrent operations to complete")
+		}
+	}
+
+	if len(tokens) != numGoroutines {
+		t.Errorf("Expected %d tokens, got %d", numGoroutines, len(tokens))
+	}
+
+	for i, token := range tokens {
+		if token.AccessToken != "refreshed-token" {
+			t.Errorf("Token %d: expected 'refreshed-token', got '%s'", i, token.AccessToken)
+		}
+	}
+
+	mu.Lock()
+	finalCallCount := callCount
+	mu.Unlock()
+
+	if finalCallCount != 1 {
+		t.Errorf("Thundering herd: SSO was called %d times, expected exactly 1", finalCallCount)
+	}
+}
+
+func TestConcurrentForceRefresh(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		time.Sleep(50 * time.Millisecond)
+		response := map[string]interface{}{
+			"access_token": "force-refreshed-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("Failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	credentials := NewOAuth2ClientCredentials("test-client", "test-secret", server.URL)
+	credentials.cachedToken = RefreshTokenResponse{
+		AccessToken: "old-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+
+	const numGoroutines = 20
+	results := make(chan RefreshTokenResponse, numGoroutines)
+	errors := make(chan error, numGoroutines)
+
+	var ready sync.WaitGroup
+	ready.Add(numGoroutines)
+	gate := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			ready.Done()
+			<-gate
+			token, err := credentials.GetToken(context.TODO(), GetTokenOptions{ForceRefresh: true})
+			if err != nil {
+				errors <- err
+			} else {
+				results <- token
+			}
+		}()
+	}
+
+	ready.Wait()
+	close(gate)
+
+	var tokens []RefreshTokenResponse
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case token := <-results:
+			tokens = append(tokens, token)
+		case err := <-errors:
+			t.Errorf("Unexpected error in concurrent access: %v", err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timeout waiting for concurrent operations to complete")
+		}
+	}
+
+	if len(tokens) != numGoroutines {
+		t.Errorf("Expected %d tokens, got %d", numGoroutines, len(tokens))
+	}
+
+	for i, token := range tokens {
+		if token.AccessToken != "force-refreshed-token" {
+			t.Errorf("Token %d: expected 'force-refreshed-token', got '%s'", i, token.AccessToken)
+		}
+	}
+
+	mu.Lock()
+	finalCallCount := callCount
+	mu.Unlock()
+
+	if finalCallCount != 1 {
+		t.Errorf("Thundering herd: SSO was called %d times, expected exactly 1", finalCallCount)
 	}
 }


### PR DESCRIPTION
- Upgrades `tokenMutex` from `sync.Mutex` to `sync.RWMutex` and adds an atomic generation counter to OAuth2ClientCredentials
- Introduces double-checked locking for token refreshes such that concurrent goroutines coalesce into a single SSO request per refresh cycle
- When the token is valid, callers acquire a shared read lock and return immediately with no contention. When it's expired (or within the 5-minute early-refresh window), all concurrent callers queue on an exclusive write lock so only one hits SSO. The rest will detect the generation change and pick up the fresh token when they get through.
- - ForceRefresh callers also coalesce such that concurrent force-refresh requests result in exactly 1 SSO call


https://redhat.atlassian.net/browse/RHCLOUD-47739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved concurrent token refresh coordination to guarantee exactly one authentication server call when multiple goroutines access tokens simultaneously
  - Enhanced token caching with atomic generation counter to prevent race conditions
  - Better handling of stale tokens in concurrent scenarios

* **Documentation**
  - Updated security guidelines clarifying concurrent token refresh behavior and in-memory caching mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->