### PR TITLE
RHCLOUD-48468 - Add consistency token support to ListWorkspaces()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
           args: --verbose ./kessel/...
       - name: Lint examples individually
         run: |
+          golangci-lint cache clean
           # Lint each example file separately since they each have main()
           for file in examples/*/*.go; do
             echo "Linting $file"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+          skip-cache: true
           args: --verbose ./kessel/...
       - name: Lint examples individually
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint examples individually
         run: |
           # Lint each example file separately since they each have main()
-          for file in examples/grpc/*.go examples/rbac/*.go; do
+          for file in examples/*/*.go; do
             echo "Linting $file"
             golangci-lint run --verbose "$file"
           done

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOBIN?=$(shell go env GOBIN)
 GOFLAGS_MOD ?=
 VERSION=$(shell git describe --tags --always)
 DOCKER := $(shell type -P podman || type -P docker)
+GOLANGCI_LINT_IMAGE ?= golangci/golangci-lint:v2.12.2
 GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
@@ -33,7 +34,7 @@ build: .env ## Build example binaries
 .PHONY: lint
 lint: ## Run golangci-lint
 	@echo "Running golangci-lint"
-	@$(DOCKER) run -t --rm -v $(PWD):/app -w /app golangci/golangci-lint:v2.1 sh -c '\
+	@$(DOCKER) run -t --rm -v $(PWD):/app -w /app $(GOLANGCI_LINT_IMAGE) sh -c '\
 		echo "Linting SDK code..."; \
 		golangci-lint run -v ./kessel/...; \
 		echo "Linting example files individually..."; \

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -126,7 +126,7 @@ Use the helper functions in `kessel/rbac/v2/utils.go` to build protobuf referenc
 `ListWorkspaces` returns `iter.Seq2[*StreamedListObjectsResponse, error]` and handles pagination internally (continuation pages use limit 1000, follows continuation tokens). Use Go range-over-func:
 
 ```go
-for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, subject, relation, "") {
+for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, subject, relation, "", nil) {
     if err != nil { break }
     // process resp
 }

--- a/examples/rbac/list_workspaces.go
+++ b/examples/rbac/list_workspaces.go
@@ -40,7 +40,7 @@ func listWorkspaces() {
 
 	// Iterate one-by-one (lazy, constant memory)
 	fmt.Println("Listing workspaces:")
-	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", nil) {
+	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "") {
 		if err != nil {
 			log.Fatalf("Error listing workspaces: %v", err)
 		}
@@ -51,7 +51,7 @@ func listWorkspaces() {
 	// Materialise all workspaces into a slice
 	fmt.Println("\nCollecting all workspaces into a slice:")
 	var allWorkspaces []*v1beta2.StreamedListObjectsResponse
-	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}) {
+	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", v2.WithConsistency(&v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}})) {
 		if err != nil {
 			log.Fatalf("Error listing workspaces: %v", err)
 		}

--- a/examples/rbac/list_workspaces.go
+++ b/examples/rbac/list_workspaces.go
@@ -40,7 +40,7 @@ func listWorkspaces() {
 
 	// Iterate one-by-one (lazy, constant memory)
 	fmt.Println("Listing workspaces:")
-	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}) {
+	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", nil) {
 		if err != nil {
 			log.Fatalf("Error listing workspaces: %v", err)
 		}

--- a/examples/rbac/list_workspaces.go
+++ b/examples/rbac/list_workspaces.go
@@ -38,7 +38,7 @@ func listWorkspaces() {
 	}()
 
 	fmt.Println("Listing workspaces:")
-	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "") {
+	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}) {
 		if err != nil {
 			log.Fatalf("Error listing workspaces: %v", err)
 		}

--- a/examples/rbac/list_workspaces.go
+++ b/examples/rbac/list_workspaces.go
@@ -51,7 +51,7 @@ func listWorkspaces() {
 	// Materialise all workspaces into a slice
 	fmt.Println("\nCollecting all workspaces into a slice:")
 	var allWorkspaces []*v1beta2.StreamedListObjectsResponse
-	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "") {
+	for resp, err := range v2.ListWorkspaces(ctx, inventoryClient, v2.PrincipalSubject("alice", "redhat"), "view_document", "", &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}) {
 		if err != nil {
 			log.Fatalf("Error listing workspaces: %v", err)
 		}

--- a/examples/rbac/list_workspaces.go
+++ b/examples/rbac/list_workspaces.go
@@ -25,6 +25,7 @@ func listWorkspaces() {
 
 	oauthCredentials := auth.NewOAuth2ClientCredentials(os.Getenv("AUTH_CLIENT_ID"), os.Getenv("AUTH_CLIENT_SECRET"), discovered.TokenEndpoint)
 
+	// Setup client
 	inventoryClient, conn, err := v1beta2.NewClientBuilder(os.Getenv("KESSEL_ENDPOINT")).
 		Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCredentials), nil).
 		Build()

--- a/kessel/rbac/v2/list_workspaces.go
+++ b/kessel/rbac/v2/list_workspaces.go
@@ -9,23 +9,46 @@ import (
 	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
+// ListWorkspacesOption configures a ListWorkspaces call.
+type ListWorkspacesOption func(*listWorkspacesOptions)
+
+type listWorkspacesOptions struct {
+	consistency *v1beta2.Consistency
+}
+
+// WithConsistency sets the consistency requirement for the listing request.
+func WithConsistency(c *v1beta2.Consistency) ListWorkspacesOption {
+	return func(o *listWorkspacesOptions) {
+		o.consistency = c
+	}
+}
+
 // ListWorkspaces returns a lazy iterator over all workspaces that the given
 // subject has the specified relation to. It wraps the StreamedListObjects gRPC
 // call and automatically handles continuation-token pagination across pages.
 //
 // Iterate one-by-one (lazy, low memory):
 //
-//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "", nil) {
+//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "") {
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }
 //	    fmt.Println(resp.Object.GetResourceId())
 //	}
 //
+// With a consistency requirement:
+//
+//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "",
+//	    v2.WithConsistency(&v1beta2.Consistency{
+//	        Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true},
+//	    })) {
+//	    // ...
+//	}
+//
 // Materialise into a slice (eager, all results in memory):
 //
 //	var all []*v1beta2.StreamedListObjectsResponse
-//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "", nil) {
+//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "") {
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }
@@ -37,8 +60,13 @@ func ListWorkspaces(
 	subject *v1beta2.SubjectReference,
 	relation string,
 	continuationToken string,
-	consistency *v1beta2.Consistency,
+	opts ...ListWorkspacesOption,
 ) iter.Seq2[*v1beta2.StreamedListObjectsResponse, error] {
+	var options listWorkspacesOptions
+	for _, o := range opts {
+		o(&options)
+	}
+
 	return func(yield func(*v1beta2.StreamedListObjectsResponse, error) bool) {
 		for {
 			var pagination *v1beta2.RequestPagination
@@ -54,7 +82,7 @@ func ListWorkspaces(
 				Relation:    relation,
 				Subject:     subject,
 				Pagination:  pagination,
-				Consistency: consistency,
+				Consistency: options.consistency,
 			}
 
 			stream, err := inventory.StreamedListObjects(ctx, request)

--- a/kessel/rbac/v2/list_workspaces.go
+++ b/kessel/rbac/v2/list_workspaces.go
@@ -15,7 +15,7 @@ import (
 //
 // Iterate one-by-one (lazy, low memory):
 //
-//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "") {
+//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "", nil) {
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }
@@ -25,7 +25,7 @@ import (
 // Materialise into a slice (eager, all results in memory):
 //
 //	var all []*v1beta2.StreamedListObjectsResponse
-//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "") {
+//	for resp, err := range v2.ListWorkspaces(ctx, client, subject, "viewer", "", nil) {
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }

--- a/kessel/rbac/v2/list_workspaces.go
+++ b/kessel/rbac/v2/list_workspaces.go
@@ -15,6 +15,7 @@ func ListWorkspaces(
 	subject *v1beta2.SubjectReference,
 	relation string,
 	continuationToken string,
+	consistency *v1beta2.Consistency,
 ) iter.Seq2[*v1beta2.StreamedListObjectsResponse, error] {
 	return func(yield func(*v1beta2.StreamedListObjectsResponse, error) bool) {
 		for {
@@ -27,10 +28,11 @@ func ListWorkspaces(
 			}
 
 			request := &v1beta2.StreamedListObjectsRequest{
-				ObjectType: WorkspaceType(),
-				Relation:   relation,
-				Subject:    subject,
-				Pagination: pagination,
+				ObjectType:  WorkspaceType(),
+				Relation:    relation,
+				Subject:     subject,
+				Pagination:  pagination,
+				Consistency: consistency,
 			}
 
 			stream, err := inventory.StreamedListObjects(ctx, request)

--- a/kessel/rbac/v2/list_workspaces_test.go
+++ b/kessel/rbac/v2/list_workspaces_test.go
@@ -61,6 +61,7 @@ func TestListWorkspaces(t *testing.T) {
 		streamErr            error
 		relation             string
 		continuationToken    string
+		consistency          *v1beta2.Consistency
 		expectedError        bool
 		expectedRequestCount int
 		validateRequests     func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest)
@@ -72,6 +73,7 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "member",
 			continuationToken:    "",
+			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -89,6 +91,7 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "viewer",
 			continuationToken:    "",
+			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 2,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -112,6 +115,7 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "admin",
 			continuationToken:    "",
+			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -124,6 +128,7 @@ func TestListWorkspaces(t *testing.T) {
 			streamErr:            &mockStreamError{message: "stream failed"},
 			relation:             "member",
 			continuationToken:    "",
+			consistency:          nil,
 			expectedError:        true,
 			expectedRequestCount: 1,
 			validateRequests:     nil,
@@ -135,6 +140,7 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "member",
 			continuationToken:    "resume-from-here",
+			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -143,6 +149,60 @@ func TestListWorkspaces(t *testing.T) {
 				require.NotNil(t, req.Pagination)
 				require.NotNil(t, req.Pagination.ContinuationToken)
 				assert.Equal(t, "resume-from-here", *req.Pagination.ContinuationToken)
+			},
+		},
+		{
+			name: "passes consistency to every request",
+			responses: []*v1beta2.StreamedListObjectsResponse{
+				{Pagination: &v1beta2.ResponsePagination{ContinuationToken: ""}},
+			},
+			relation:             "member",
+			continuationToken:    "",
+			consistency:          &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}},
+			expectedError:        false,
+			expectedRequestCount: 1,
+			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
+				require.Len(t, requests, 1)
+				req := requests[0]
+				require.NotNil(t, req.Consistency)
+				ml, ok := req.Consistency.Requirement.(*v1beta2.Consistency_MinimizeLatency)
+				require.True(t, ok)
+				assert.True(t, ml.MinimizeLatency)
+			},
+		},
+		{
+			name: "nil consistency is fine",
+			responses: []*v1beta2.StreamedListObjectsResponse{
+				{Pagination: &v1beta2.ResponsePagination{ContinuationToken: ""}},
+			},
+			relation:             "member",
+			continuationToken:    "",
+			consistency:          nil,
+			expectedError:        false,
+			expectedRequestCount: 1,
+			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
+				require.Len(t, requests, 1)
+				assert.Nil(t, requests[0].Consistency)
+			},
+		},
+		{
+			name: "consistency preserved across paginated pages",
+			responses: []*v1beta2.StreamedListObjectsResponse{
+				{Pagination: &v1beta2.ResponsePagination{ContinuationToken: "page-2-token"}},
+			},
+			relation:             "view",
+			continuationToken:    "",
+			consistency:          &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}},
+			expectedError:        false,
+			expectedRequestCount: 2,
+			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
+				require.Len(t, requests, 2)
+				for i, req := range requests {
+					require.NotNil(t, req.Consistency, "request %d should have consistency set", i)
+					ml, ok := req.Consistency.Requirement.(*v1beta2.Consistency_MinimizeLatency)
+					require.True(t, ok, "request %d should have MinimizeLatency requirement", i)
+					assert.True(t, ml.MinimizeLatency, "request %d MinimizeLatency should be true", i)
+				}
 			},
 		},
 	}
@@ -157,7 +217,7 @@ func TestListWorkspaces(t *testing.T) {
 			subject := PrincipalSubject("user123", "redhat")
 
 			var iterationErr error
-			for _, err := range ListWorkspaces(context.Background(), mockClient, subject, tt.relation, tt.continuationToken) {
+			for _, err := range ListWorkspaces(context.Background(), mockClient, subject, tt.relation, tt.continuationToken, tt.consistency) {
 				if err != nil {
 					iterationErr = err
 					break

--- a/kessel/rbac/v2/list_workspaces_test.go
+++ b/kessel/rbac/v2/list_workspaces_test.go
@@ -61,7 +61,7 @@ func TestListWorkspaces(t *testing.T) {
 		streamErr            error
 		relation             string
 		continuationToken    string
-		consistency          *v1beta2.Consistency
+		opts                 []ListWorkspacesOption
 		expectedError        bool
 		expectedRequestCount int
 		validateRequests     func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest)
@@ -73,7 +73,6 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "member",
 			continuationToken:    "",
-			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -91,7 +90,6 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "viewer",
 			continuationToken:    "",
-			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 2,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -115,7 +113,6 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "admin",
 			continuationToken:    "",
-			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -128,7 +125,6 @@ func TestListWorkspaces(t *testing.T) {
 			streamErr:            &mockStreamError{message: "stream failed"},
 			relation:             "member",
 			continuationToken:    "",
-			consistency:          nil,
 			expectedError:        true,
 			expectedRequestCount: 1,
 			validateRequests:     nil,
@@ -140,7 +136,6 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "member",
 			continuationToken:    "resume-from-here",
-			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -156,9 +151,11 @@ func TestListWorkspaces(t *testing.T) {
 			responses: []*v1beta2.StreamedListObjectsResponse{
 				{Pagination: &v1beta2.ResponsePagination{ContinuationToken: ""}},
 			},
-			relation:             "member",
-			continuationToken:    "",
-			consistency:          &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}},
+			relation:          "member",
+			continuationToken: "",
+			opts: []ListWorkspacesOption{
+				WithConsistency(&v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}),
+			},
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -177,7 +174,6 @@ func TestListWorkspaces(t *testing.T) {
 			},
 			relation:             "member",
 			continuationToken:    "",
-			consistency:          nil,
 			expectedError:        false,
 			expectedRequestCount: 1,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -190,9 +186,11 @@ func TestListWorkspaces(t *testing.T) {
 			responses: []*v1beta2.StreamedListObjectsResponse{
 				{Pagination: &v1beta2.ResponsePagination{ContinuationToken: "page-2-token"}},
 			},
-			relation:             "view",
-			continuationToken:    "",
-			consistency:          &v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}},
+			relation:          "view",
+			continuationToken: "",
+			opts: []ListWorkspacesOption{
+				WithConsistency(&v1beta2.Consistency{Requirement: &v1beta2.Consistency_MinimizeLatency{MinimizeLatency: true}}),
+			},
 			expectedError:        false,
 			expectedRequestCount: 2,
 			validateRequests: func(t *testing.T, requests []*v1beta2.StreamedListObjectsRequest) {
@@ -217,7 +215,7 @@ func TestListWorkspaces(t *testing.T) {
 			subject := PrincipalSubject("user123", "redhat")
 
 			var iterationErr error
-			for _, err := range ListWorkspaces(context.Background(), mockClient, subject, tt.relation, tt.continuationToken, tt.consistency) {
+			for _, err := range ListWorkspaces(context.Background(), mockClient, subject, tt.relation, tt.continuationToken, tt.opts...) {
 				if err != nil {
 					iterationErr = err
 					break


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-48468

## Summary
- add an optional consistency argument to `v2.ListWorkspaces()` and forward it on every `StreamedListObjectsRequest`, including follow-up paginated requests
- expand `list_workspaces` tests to cover propagated consistency, nil consistency, and pagination behavior
- update the RBAC example to show passing a consistency requirement and bump the local `golangci-lint` image in `Makefile` so `make lint` works with Go 1.25

## Test plan
- [x] `make lint`
- [x] `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace listing accepts an optional consistency parameter to control query behavior.

* **Tests**
  * Expanded tests to validate consistency handling and pagination preservation.

* **Chores**
  * Made lint image configurable; CI linting now covers more example files, disables cache, and cleans cache before runs; checkout step selects PR head or commit SHA.

* **Documentation**
  * Updated integration example to show calling the updated workspace listing with the consistency argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->